### PR TITLE
RoslyJump VSIX support for VS 2022

### DIFF
--- a/dngrep.core.xunit/dngrep.core.xunit.csproj
+++ b/dngrep.core.xunit/dngrep.core.xunit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>


### PR DESCRIPTION
Related PRs:
1. [RoslyJump Support for VS 2022 | psxvoid/RoslyJump](https://github.com/psxvoid/RoslyJump/pull/15)